### PR TITLE
Muutettu setup_app -> init_app

### DIFF
--- a/source/viikko3.html.erb
+++ b/source/viikko3.html.erb
@@ -768,7 +768,7 @@ published: true
 
   from flask_login import LoginManager
   login_manager = LoginManager()
-  login_manager.setup_app(app)
+  login_manager.init_app(app)
 
   login_manager.login_view = "auth_login"
   login_manager.login_message = "Please login to use this functionality."


### PR DESCRIPTION
Voi tuottaa ongelmia jos käyttää setup_app, eikä uudempaa init_app
Setup_app: This method has been deprecated. Please use LoginManager.init_app() instead
https://flask-login.readthedocs.io/en/latest/