### PR TITLE
fixed example output

### DIFF
--- a/source/python-alkeet.html.erb
+++ b/source/python-alkeet.html.erb
@@ -766,7 +766,7 @@
 <% end %>
 
 <% partial 'partials/sample_output' do %>
-  Hei
+  Heippa
 <% end %>
 
 


### PR DESCRIPTION
The example output should be "Heippa" instead of "Hei".