### PR TITLE
Poistettu sulkuja

### DIFF
--- a/source/viikko5.html.erb
+++ b/source/viikko5.html.erb
@@ -145,7 +145,7 @@ def login_required(role="ANY"):
             if not current_user:
                 return login_manager.unauthorized()
           
-            if not current_user.is_authenticated():
+            if not current_user.is_authenticated:
                 return login_manager.unauthorized()
             
             unauthorized = False
@@ -211,7 +211,7 @@ def login_required(role="ANY"):
             if not current_user:
                 return login_manager.unauthorized()
 
-            if not current_user.is_authenticated():
+            if not current_user.is_authenticated:
                 return login_manager.unauthorized()
             
             unauthorized = False


### PR DESCRIPTION
if not current_user.is_authenticated:ista poistettu kahdesta kohtaa sulut perästä, koska kyseessä ei ole enää funktio vaan boolean uudessa Flaskissa https://stackoverflow.com/questions/32750526/flask-login-raises-typeerror-bool-object-is-not-callable-when-trying-to-overr ja https://stackoverflow.com/questions/33062109/typeerror-bool-object-is-not-callable-g-user-is-authenticated